### PR TITLE
Show the encounter mechanic tooltip on mouseover

### DIFF
--- a/BossMechanicFrames.lua
+++ b/BossMechanicFrames.lua
@@ -5,7 +5,7 @@ local myname, ns = ...
 local frames = {}
 local function CreateBossMechanicFrame()
 	local parent = GarrisonMissionFrame.MissionTab.MissionList
-	local template = "GarrisonMissionEnemyLargeMechanicTemplate"
+	local template = "GarrisonMissionLargeMechanicTemplate"
 	local f = CreateFrame("Frame", nil, parent, template)
 
 	local label = f:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")

--- a/MissionList.lua
+++ b/MissionList.lua
@@ -51,6 +51,7 @@ local function UpdateMission(frame)
 			local mech = ns.GetBossMechanicFrame()
 
 			mech.label:SetText(GetCounterText(mechanic.name, missionID))
+			mech.info = mechanic
 			mech.Icon:SetTexture(mechanic.icon)
 
 			mech:SetParent(frame)


### PR DESCRIPTION
I wasn't sure if you omitted this on purpose. It felt odd to me to have the icons block mouseover/click on the mission without having a tooltip.
