### PR TITLE
Disable mouseover on the encounter mechanic frames in the list

### DIFF
--- a/BossMechanicFrames.lua
+++ b/BossMechanicFrames.lua
@@ -5,12 +5,15 @@ local myname, ns = ...
 local frames = {}
 local function CreateBossMechanicFrame()
 	local parent = GarrisonMissionFrame.MissionTab.MissionList
-	local template = "GarrisonMissionEnemyLargeMechanicTemplate"
+	local template = "GarrisonMissionLargeMechanicTemplate"
 	local f = CreateFrame("Frame", nil, parent, template)
 
 	local label = f:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
 	label:SetPoint("BOTTOM", 0, -16)
 	f.label = label
+
+	-- until we have a nice tooltip to display, don't handle mouse input at all
+	f:EnableMouse(false)
 
 	table.insert(frames, f)
 


### PR DESCRIPTION
We'd love to have a good tooltip here, but until we have a good tooltip,
these frames should ignore the mouse entirely. That prevents the
annoying flashing of the row highlight as you mouse over a row of
mechanics.

Also tweak the template we use slightly. We don't need the checkmark
support, so we can use one of the parent templates instead. It doesn't
really affect anything, it just seemed unnecessary to pull in the
checkmark machinery if we weren't going to use it.
