### PR TITLE
Treat combat ally as unavailable

### DIFF
--- a/MissionListBossMechanics.lua
+++ b/MissionListBossMechanics.lua
@@ -6,6 +6,7 @@ ns.inactive_statii = {
 	[GARRISON_FOLLOWER_ON_MISSION] = true,
 	[GARRISON_FOLLOWER_INACTIVE] = true,
 	[GARRISON_FOLLOWER_WORKING] = true,
+	[GARRISON_FOLLOWER_COMBAT_ALLY] = true,
 }
 function ns.IsFollowerAvailable(guid, excludeparty)
 	local status = C_Garrison.GetFollowerStatus(guid)


### PR DESCRIPTION
In Legion, a follower can be set as a combat ally - similar to WoD where followers were assigned to buildings. The `GARRISON_FOLLOWER_COMBAT_ALLY` should probably be treated the same as `GARRISON_FOLLOWER_WORKING`.
