### PR TITLE
Right-click to remove OrderHall follower causes error

### DIFF
--- a/FollowerClick.lua
+++ b/FollowerClick.lua
@@ -4,9 +4,10 @@ local myname, ns = ...
 
 local function Hook(missionpage)
 	local function RemoveFollower(followerID)
+		local missionframe = missionpage:GetParent():GetParent()
 		for i,frame in pairs(missionpage.Followers) do
 			if frame.info and frame.info.followerID == followerID then
-				return GarrisonMissionFrame:RemoveFollowerFromMission(frame, true)
+				return missionframe:RemoveFollowerFromMission(frame, true)
 			end
 		end
 	end


### PR DESCRIPTION
```
2x ...risonTemplates\Blizzard_GarrisonMissionTemplates.lua:641: attempt to index field 'missionInfo' (a nil value)
...risonTemplates\Blizzard_GarrisonMissionTemplates.lua:641: in function 'RemoveFollowerFromMission'
...s\Blizzard_GarrisonUI\Blizzard_GarrisonMissionUI.lua:358: in function <...s\Blizzard_GarrisonUI\Blizzard_GarrisonMissionUI.lua:357>
(tail call): ?
(tail call): ?
[string "*:OnClick"]:4: in function <[string "*:OnClick"]:1>
```
